### PR TITLE
chore: 更新模型CNB_URL

### DIFF
--- a/module/ohMyRime/resources.go
+++ b/module/ohMyRime/resources.go
@@ -3,5 +3,5 @@ package ohMyRime
 // urls for resources
 const (
 	LMDG_GITHUB_URL = "https://github.com/amzxyz/RIME-LMDG/releases/download/LTS/wanxiang-lts-zh-hans.gram"
-	LMDG_CNB_URL    = "https://cnb.cool/Mintimate/rime/oh-my-rime/-/releases/download/latest/wanxiang-lts-zh-hans.gram"
+	LMDG_CNB_URL    = "https://cnb.cool/amzxyz/rime-wanxiang/-/releases/download/model/wanxiang-lts-zh-hans.gram"
 )


### PR DESCRIPTION
模型CNB_URL更新为官方仓库URL（版本不一致）